### PR TITLE
클라우드센터VM 마법사 UI 프로토타입 작성

### DIFF
--- a/src/features/cloud-vm-wizard.html
+++ b/src/features/cloud-vm-wizard.html
@@ -321,7 +321,7 @@
                                                         </label>
                                                     </div>
                                                     <div class="pf-c-form__group-control">
-                                                        <select class="pf-c-form-control" id="form-select-cloud-vm-svc-parent" name="form-select-cloud-vm-svc-parent" style="width:40%;">
+                                                        <select class="pf-c-form-control" id="form-select-cloud-vm-svc-parent" name="form-select-cloud-vm-svc-parent" style="width:40%;" disabled>
                                                             <option selected>선택하십시오</option>
                                                             <option value="16">cloud0</option>
                                                             <option value="32">br0</option>
@@ -410,24 +410,22 @@
                                             <div class="pf-c-form__group-label">
                                                 <label class="pf-c-form__label" for="form-input-cloud-vm-svc-nic-ip">
                                                     <span class="pf-c-form__label-text">서비스 NIC IP</span>
-                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
                                                 </label>
                                             </div>
                                             <div class="pf-c-form__group-control pf-m-inline">
-                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-nic-ip" name="form-input-cloud-vm-svc-nic-ip" placeholder="xxx.xxx.xxx.xxx/xx 형식으로 입력"/>
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-nic-ip" name="form-input-cloud-vm-svc-nic-ip" placeholder="xxx.xxx.xxx.xxx/xx 형식으로 입력" disabled/>
                                                 <label class="pf-c-form__label-text" style="margin-top:8px" for="form-input-cloud-vm-svc-vlan">VLAN ID</label>
-                                                <input class="pf-c-form-control" style="width:10%" type="text" id="form-input-cloud-vm-svc-vlan" name="form-input-cloud-vm-svc-vlan"/>
+                                                <input class="pf-c-form-control" style="width:10%" type="text" id="form-input-cloud-vm-svc-vlan" name="form-input-cloud-vm-svc-vlan" disabled/>
                                             </div>
                                         </div>
                                         <div class="pf-c-form__group">
                                             <div class="pf-c-form__group-label">
                                                 <label class="pf-c-form__label" for="form-input-cloud-vm-svc-gw">
                                                     <span class="pf-c-form__label-text">서비스 NIC Gateway</span>
-                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
                                                 </label>
                                             </div>
                                             <div class="pf-c-form__group-control pf-m-inline">
-                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-gw" name="form-input-cloud-vm-svc-gw" placeholder="xxx.xxx.xxx.xxx 형식으로 입력"/>
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-gw" name="form-input-cloud-vm-svc-gw" placeholder="xxx.xxx.xxx.xxx 형식으로 입력" disabled/>
                                             </div>
                                         </div>
                                     </section>

--- a/src/features/cloud-vm-wizard.html
+++ b/src/features/cloud-vm-wizard.html
@@ -73,6 +73,120 @@
                                     장애조치 클러스터는 클라우드센터 VM이 실행 중인 호스트에 장애가 발생하는 경우 클라우드센터 VM을 안전하게 다른 호스트에서 실행하도록 하기 위해 구성합니다.
                                     장애조치 클러스터를 구성하기 위해 필요한 정보를 아래에 입력하십시오. 
                                 </p>
+                                <form novalidate class="pf-c-form pf-m-horizontal" style="margin-left:15px;margin-top:32px">
+                                    <section class="pf-c-form__section">
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-member-number">
+                                                    <span class="pf-c-form__label-text">클러스터 멤버수</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:15%" type="text" id="form-input-cloud-vm-failover-cluster-member-number" name="form-input-cloud-vm-failover-cluster-member-number" value="3" readonly>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__field-group">
+                                            <div class="pf-c-form__field-group-header"  style="padding-bottom:8px;">
+                                                <div class="pf-c-form__field-group-header-main">
+                                                    <div class="pf-c-form__field-group-header-title">
+                                                        <div class="pf-c-form__field-group-header-title-text">호스트 #1 정보</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="pf-c-form__field-group-body" style="padding-top:0px;">
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host1-name">
+                                                            <span class="pf-c-form__label-text">Hostname</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host1-name" name="form-input-cloud-vm-failover-cluster-host1-name" required />
+                                                    </div>
+                                                </div>
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host1-addr">
+                                                            <span class="pf-c-form__label-text">IP Address</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host1-addr" name="form-input-cloud-vm-failover-cluster-host1-addr" required />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__field-group">
+                                            <div class="pf-c-form__field-group-header"  style="padding-bottom:8px;">
+                                                <div class="pf-c-form__field-group-header-main">
+                                                    <div class="pf-c-form__field-group-header-title">
+                                                        <div class="pf-c-form__field-group-header-title-text">호스트 #2 정보</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="pf-c-form__field-group-body" style="padding-top:0px;">
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host2-name">
+                                                            <span class="pf-c-form__label-text">Hostname</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host2-name" name="form-input-cloud-vm-failover-cluster-host2-name" required />
+                                                    </div>
+                                                </div>
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host2-addr">
+                                                            <span class="pf-c-form__label-text">IP Address</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host2-addr" name="form-input-cloud-vm-failover-cluster-host2-addr" required />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__field-group">
+                                            <div class="pf-c-form__field-group-header"  style="padding-bottom:8px;">
+                                                <div class="pf-c-form__field-group-header-main">
+                                                    <div class="pf-c-form__field-group-header-title">
+                                                        <div class="pf-c-form__field-group-header-title-text">호스트 #3 정보</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="pf-c-form__field-group-body" style="padding-top:0px;">
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host3-name">
+                                                            <span class="pf-c-form__label-text">Hostname</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host3-name" name="form-input-cloud-vm-failover-cluster-host3-name" required />
+                                                    </div>
+                                                </div>
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-input-cloud-vm-failover-cluster-host3-addr">
+                                                            <span class="pf-c-form__label-text">IP Address</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <input class="pf-c-form-control" style="width:70%" type="text" id="form-input-cloud-vm-failover-cluster-host3-addr" name="form-input-cloud-vm-failover-cluster-host3-addr" required />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-compute">
@@ -81,6 +195,71 @@
                                     클라우드센터 VM의 CPU 및 Memory, ROOT Disk 등의 정보를 설정합니다. 
                                     아래의 항목에 적합한 값을 선택하여 입력하십시오.
                                 </p>
+                                <form novalidate class="pf-c-form pf-m-horizontal" style="margin-left:15px;margin-top:32px">
+                                    <section class="pf-c-form__section">
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-select-cloud-vm-compute-cpu-core">
+                                                    <span class="pf-c-form__label-text">CPU Core</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <select class="pf-c-form-control" id="form-select-cloud-vm-compute-cpu-core" name="form-select-cloud-vm-compute-cpu-core" style="width:40%;">
+                                                    <option selected>선택하십시오</option>
+                                                    <option value="4">4 vCore</option>
+                                                    <option value="8">8 vCore</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-select-cloud-vm-compute-memory">
+                                                    <span class="pf-c-form__label-text">Memory</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control">
+                                                <select class="pf-c-form-control" id="form-select-cloud-vm-compute-memory" name="form-select-cloud-vm-compute-memory" style="width:40%;">
+                                                    <option selected>선택하십시오</option>
+                                                    <option value="16">8 GiB</option>
+                                                    <option value="32">16 GiB</option>
+                                                    <option value="64">32 GiB</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-select-cloud-vm-root-disk">
+                                                    <span class="pf-c-form__label-text">ROOT Disk</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" id="form-select-cloud-vm-root-disk" name="form-select-cloud-vm-root-disk" style="width:40%">
+                                                    <span class="pf-c-form__label-text">70 GiB (THIN Provisioning)</span>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
+                                <br/>
+                                <div class="pf-c-alert pf-m-info pf-m-inline" aria-label="VM Compute Info" style="margin-left:15px;margin-top:32px">
+                                    <div class="pf-c-alert__icon">
+                                        <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                                    </div>
+                                    <p class="pf-c-alert__title pf-m-truncate">
+                                        <strong><span class="pf-screen-reader">Info alert:</span>컴퓨트 자원 구성 시 참고사항</strong>
+                                    </p>
+                                    <div class="pf-c-alert__description">
+                                        <p>클라우드센터 VM의 Compute 자원은 클라우드센터가 관리해야 할 호스트의 수에 따라 탄력적으로 선택합니다. </p>
+                                        <p>
+                                            가상머신이 컨트롤 할 호스트의 수가 10개 미만이면 4 vCore를, 그 이상이면 8 vCore를 선택하십시오. 
+                                            메모리는 컨트롤할 호스트의 수가 10개 미만이면 8GiB를, 10 ~ 20개 이면 16GiB를, 21개 이상이면 32GiB를 선택해야 합니다. 
+                                        </p>
+                                        <p>ROOT Disk의 크기는 70GiB를 디스크가 Thin Provisioning 방식으로 제공됩니다. </p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-network">
@@ -89,6 +268,87 @@
                                     클라우드센터 VM이 사용할 관리 네트워크용 NIC 정보를 설정합니다. 
                                     아래의 항목에 적합한 값을 선택하여 입력하십시오.
                                 </p>
+                                <form novalidate class="pf-c-form pf-m-horizontal" style="margin-left:15px;margin-top:32px">
+                                    <section class="pf-c-form__section">
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label">
+                                                    <span class="pf-c-form__label-text">네트워크 구성</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-stack" style="margin-top:8px">
+                                                <div class="pf-c-check">
+                                                    <input class="pf-c-check__input" type="checkbox" id="form-checkbox-mngt-network" name="form-checkbox-mngt-network" checked disabled/>
+                                                    <label class="pf-c-check__label" style="margin-top:5px" for="form-checkbox-mngt-network">관리네트워크</label>
+                                                </div>
+                                                <div class="pf-c-check">
+                                                    <input class="pf-c-check__input" type="checkbox" id="form-checkbox-svc-network" name="form-checkbox-svc-network" />
+                                                    <label class="pf-c-check__label" style="margin-top:5px" for="form-checkbox-svc-network">서비스네트워크</label>
+                                                </div>    
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__field-group">
+                                            <div class="pf-c-form__field-group-header"  style="padding-bottom:8px;">
+                                                <div class="pf-c-form__field-group-header-main">
+                                                    <div class="pf-c-form__field-group-header-title">
+                                                        <div class="pf-c-form__field-group-header-title-text">가상머신에 할당할 Parent Bridge</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="pf-c-form__field-group-body">
+                                                <div class="pf-c-form__group">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-select-cloud-vm-mngt-parent">
+                                                            <span class="pf-c-form__label-text">관리네트워크</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <select class="pf-c-form-control" id="form-select-cloud-vm-mngt-parent" name="form-select-cloud-vm-mngt-parent" style="width:40%;">
+                                                            <option selected>선택하십시오</option>
+                                                            <option value="16">cloud0</option>
+                                                            <option value="32">br0</option>
+                                                            <option value="64">br1</option>
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                                <div class="pf-c-form__group" style="padding:0px;">
+                                                    <div class="pf-c-form__group-label">
+                                                        <label class="pf-c-form__label" for="form-select-cloud-vm-svc-parent">
+                                                            <span class="pf-c-form__label-text">서비스네트워크</span>
+                                                            <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="pf-c-form__group-control">
+                                                        <select class="pf-c-form-control" id="form-select-cloud-vm-svc-parent" name="form-select-cloud-vm-svc-parent" style="width:40%;">
+                                                            <option selected>선택하십시오</option>
+                                                            <option value="16">cloud0</option>
+                                                            <option value="32">br0</option>
+                                                            <option value="64">br1</option>
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
+                                <div class="pf-c-alert pf-m-info pf-m-inline" aria-label="VM Compute Info" style="margin-left:15px;margin-top:32px">
+                                    <div class="pf-c-alert__icon">
+                                        <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                                    </div>
+                                    <p class="pf-c-alert__title pf-m-truncate">
+                                        <strong><span class="pf-screen-reader">Info alert:</span>네트워크 구성 시 참고사항</strong>
+                                    </p>
+                                    <div class="pf-c-alert__description">
+                                        <p>클라우드센터에 접근하고자 하는 네트워크 위치에 따라 가상머신에 할당할 네트워크와 네트워크의 상위 브릿지를 선택합니다. </p>
+                                        <p>
+                                            관리네트워크는 호스트를 관리하기 위해 필수적인 네트워크이며, 기본 선택되어 있고, 선택 여부를 변경할 수 없습니다. 
+                                            서비스네트워크는 사용자가 접근하고자 하는 네트워크 위치이며, 관리네트워크와 서비스네트워크가 다른 경우 선택합니다. 
+                                        </p>
+                                        <p>가상머신에 네트워크를 할당하기 전에 반드시 상위 브릿지를 먼저 생성해야 합니다. </p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-additional">
@@ -96,6 +356,82 @@
                                 <p>
                                     클라우드센터 VM에 호스트명 등의 부가적인 네트워크 정보를 설정합니다. 아래의 항목에 값을 입력하십시오.
                                 </p>
+                                <form novalidate class="pf-c-form pf-m-horizontal" style="margin-left:15px;margin-top:32px">
+                                    <section class="pf-c-form__section">
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label">
+                                                    <span class="pf-c-form__label-text">정보 입력 소스</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-check__input" style="margin-top:12px;margin-right:5px" type="checkbox" id="form-input-cloud-vm-additional-file" name="form-input-cloud-vm-additional-file"/>
+                                                <label class="pf-c-check__label" style="margin-top:8px;margin-left:0px" for="form-input-cloud-vm-additional-file">Hosts 파일 사용</label>
+                                                <input class="pf-c-form-control" style="width:70%" type="file" id="form-input-cloud-vm-hosts-file" name="form-input-cloud-vm-hosts-file"/>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-hostname">
+                                                    <span class="pf-c-form__label-text">호스트명</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control">
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-hostname" name="form-input-cloud-vm-hostname"/>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-mngt-nic-ip">
+                                                    <span class="pf-c-form__label-text">관리 NIC IP</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-mngt-nic-ip" name="form-input-cloud-vm-mngt-nic-ip" placeholder="xxx.xxx.xxx.xxx/xx 형식으로 입력"/>
+                                                <label class="pf-c-form__label-text" style="margin-top:8px" for="form-input-cloud-vm-mngt-vlan">VLAN ID</label>
+                                                <input class="pf-c-form-control" style="width:10%" type="text" id="form-input-cloud-vm-mngt-vlan" name="form-input-cloud-vm-mngt-vlan"/>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-mngt-gw">
+                                                    <span class="pf-c-form__label-text">관리 NIC Gateway</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-mngt-gw" name="form-input-cloud-vm-mngt-gw" placeholder="xxx.xxx.xxx.xxx 형식으로 입력"/>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-svc-nic-ip">
+                                                    <span class="pf-c-form__label-text">서비스 NIC IP</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-nic-ip" name="form-input-cloud-vm-svc-nic-ip" placeholder="xxx.xxx.xxx.xxx/xx 형식으로 입력"/>
+                                                <label class="pf-c-form__label-text" style="margin-top:8px" for="form-input-cloud-vm-svc-vlan">VLAN ID</label>
+                                                <input class="pf-c-form-control" style="width:10%" type="text" id="form-input-cloud-vm-svc-vlan" name="form-input-cloud-vm-svc-vlan"/>
+                                            </div>
+                                        </div>
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-svc-gw">
+                                                    <span class="pf-c-form__label-text">서비스 NIC Gateway</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:50%" type="text" id="form-input-cloud-vm-svc-gw" name="form-input-cloud-vm-svc-gw" placeholder="xxx.xxx.xxx.xxx 형식으로 입력"/>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-ssh-key">
@@ -104,6 +440,38 @@
                                     클라우드센터 VM과 호스트, 그리고 ABLESTACK을 구성하고 있는 가상머신들과의 SSH 연결을 위해 SSH Key를 설정합니다. 
                                     미리 생성한 SSH Key 파일을 등록할 수 있습니다. 
                                 </p>
+                                <form novalidate class="pf-c-form pf-m-horizontal" style="margin-left:15px;margin-top:32px">
+                                    <section class="pf-c-form__section">
+                                        <div class="pf-c-form__group">
+                                            <div class="pf-c-form__group-label">
+                                                <label class="pf-c-form__label" for="form-input-cloud-vm-ssh-key-file">
+                                                    <span class="pf-c-form__label-text">SSH Key 파일</span>
+                                                    <span class="pf-c-form__label-required" aria-hidden="true">&#42;</span>
+                                                </label>
+                                            </div>
+                                            <div class="pf-c-form__group-control pf-m-inline">
+                                                <input class="pf-c-form-control" style="width:70%" type="file" id="form-input-cloud-vm-ssh-key-file" name="form-input-cloud-vm-ssh-key-file"/>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </form>
+                                <br/>
+                                <div class="pf-c-alert pf-m-info pf-m-inline" aria-label="VM Compute Info" style="margin-left:15px;margin-top:32px">
+                                    <div class="pf-c-alert__icon">
+                                        <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                                    </div>
+                                    <p class="pf-c-alert__title pf-m-truncate">
+                                        <strong><span class="pf-screen-reader">Info alert:</span>SSH Key 등록 참고사항</strong>
+                                    </p>
+                                    <div class="pf-c-alert__description">
+                                        <p>
+                                            SSH Key는 호스트 및 클라우드센터, 스토리지센터 가상머신 등의 ABLESTACK 구성요소 간의 암호화된 인증을 위해 사용됩니다. 
+                                        </p>
+                                        <p>
+                                            호스트 간, 가상머신 간의 모든 명령은 SSH를 이용해 전달되며 이 때 SSH Key를 이용해 인증을 처리합니다. 따라서 모든 호스트, 가상머신은 동일한 SSH Key를 사용해야 합니다.
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-review">
@@ -115,6 +483,270 @@
                                     <br/>
                                     모든 정보를 확인한 후 "배포"를 시작합니다. 
                                 </p>
+                            </div>
+                            <div class="pf-c-accordion" style="margin-top:32px;margin-left:10px">
+                                <h3>
+                                    <button class="pf-c-accordion__toggle" aria-expanded="false" id="button-accordion-cloud-vm-failover-cluster">
+                                        <span class="pf-c-accordion__toggle-text">장애조치 클러스터 설정</span>
+                                        <span class="pf-c-accordion__toggle-icon">
+                                            <i class="fas fa-angle-right" aria-hidden="true"></i>
+                                        </span>
+                                    </button>
+                                </h3>
+                                <div class="pf-c-accordion__expanded-content" id="div-accordion-cloud-vm-failover-cluster">
+                                    <div class="pf-c-accordion__expanded-content-body">
+                                        <dl class="pf-c-description-list pf-m-horizontal" style="--pf-c-description-list--RowGap: 10px;margin-left: 10px">
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">클러스터 멤버 수 </span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">3</div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">Host #1 정보</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        Hostname : <span id="span-cloud-vm-failover-cluster-host1-name">ablestack1</span><br/>
+                                                        IP Address : <span id="span-cloud-vm-failover-cluster-host1-ipaddr">192.168.0.11</span>                                                   
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">Host #2 정보</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        Hostname : <span id="span-cloud-vm-failover-cluster-host2-name">ablestack2</span><br/>
+                                                        IP Address : <span id="span-cloud-vm-failover-cluster-host2-ipaddr">192.168.0.12</span>                                                  
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">Host #3 정보</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        Hostname : <span id="span-cloud-vm-failover-cluster-host3-name">ablestack3</span><br/>
+                                                        IP Address : <span id="span-cloud-vm-failover-cluster-host3-ipaddr">192.168.0.13</span>                                                   
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="pf-c-accordion" style="margin-top:32px;margin-left:10px">
+                                <h3>
+                                    <button class="pf-c-accordion__toggle" aria-expanded="false" id="button-accordion-cloud-vm-compute-network">
+                                        <span class="pf-c-accordion__toggle-text">클라우드센터 VM 설정</span>
+                                        <span class="pf-c-accordion__toggle-icon">
+                                            <i class="fas fa-angle-right" aria-hidden="true"></i>
+                                        </span>
+                                    </button>
+                                </h3>
+                                <div class="pf-c-accordion__expanded-content" id="div-accordion-cloud-vm-compute-network">
+                                    <div class="pf-c-accordion__expanded-content-body">
+                                        <dl class="pf-c-description-list pf-m-horizontal" style="--pf-c-description-list--RowGap: 10px;margin-left: 10px">
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">CPU Core</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-cpu-core">4 Cores</span>                                              
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">Memory</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-memory">8 GiB</span>                                               
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">ROOT Disk Size</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-root-disk-size">70 GiB</span>                                                
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">네트워크 구성</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-network-config">관리네트워크, 서비스네트워크</span>                                                
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">관리용 Bridge</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-mgmt-nic-bridge">br0</span>                                                
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">서비스용 Bridge</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-svc-nic-bridge">br1</span>                                                
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="pf-c-accordion" style="margin-top:32px;margin-left:10px">
+                                <h3>
+                                    <button class="pf-c-accordion__toggle" aria-expanded="false" id="button-accordion-cloud-vm-additional">
+                                        <span class="pf-c-accordion__toggle-text">추가 네트워크 정보</span>
+                                        <span class="pf-c-accordion__toggle-icon">
+                                            <i class="fas fa-angle-right" aria-hidden="true"></i>
+                                        </span>
+                                    </button>
+                                </h3>
+                                <div class="pf-c-accordion__expanded-content" id="div-accordion-cloud-vm-additional">
+                                    <div class="pf-c-accordion__expanded-content-body">
+                                        <dl class="pf-c-description-list pf-m-horizontal" style="--pf-c-description-list--RowGap: 10px;margin-left: 10px">
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">정보 입력 소스</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-additional-hosts-source">직접 입력</span>                                              
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">호스트명</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-additional-hostname">ablestack-temis</span>                                              
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">관리 NIC 정보</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        IP Addr : <span id="span-cloud-vm-additional-mgmt-ipaddr">192.168.0.21/24</span><br/>      
+                                                        VLAN ID : <span id="span-cloud-vm-additional-mgmt-vlan-id">1001</span><br/>       
+                                                        Gateway : <span id="span-cloud-vm-additional-mgmt-gateway">192.168.0.1</span>                                           
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">서비스 NIC 정보</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        IP Addr : <span id="span-cloud-vm-additional-svc-ipaddr">172.16.0.21/24</span><br/>      
+                                                        VLAN ID : <span id="span-cloud-vm-additional-svc-vlan-id">1001</span><br/>       
+                                                        Gateway : <span id="span-cloud-vm-additional-svc-gateway">172.16.0.1</span>                                           
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="pf-c-accordion" style="margin-top:32px;margin-left:10px">
+                                <h3>
+                                    <button class="pf-c-accordion__toggle" aria-expanded="false" id="button-accordion-cloud-vm-ssh-key">
+                                        <span class="pf-c-accordion__toggle-text">SSH Key 정보</span>
+                                        <span class="pf-c-accordion__toggle-icon">
+                                            <i class="fas fa-angle-right" aria-hidden="true"></i>
+                                        </span>
+                                    </button>
+                                </h3>
+                                <div class="pf-c-accordion__expanded-content" id="div-accordion-cloud-vm-ssh-key">
+                                    <div class="pf-c-accordion__expanded-content-body">
+                                        <dl class="pf-c-description-list pf-m-horizontal" style="--pf-c-description-list--RowGap: 10px;margin-left: 10px">
+                                            <div class="pf-c-description-list__group">
+                                                <dt class="pf-c-description-list__term">
+                                                    <span class="pf-c-description-list__text">SSH Key 파일</span>
+                                                </dt>
+                                                <dd class="pf-c-description-list__description">
+                                                    <div class="pf-c-description-list__text">
+                                                        <span id="span-cloud-vm-ssh-key-file">/Document/Files/ssh-key.key</span><br/>
+                                                    </div>
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-deploy">
+                            <p>
+                                클라우드센터 가상머신을 배포 중입니다. 전체 00단계 중 00단계 진행 중입니다.  
+                            </p>
+                            <div class="pf-c-content" style="margin-top:30px;margin-left:15px">
+                                <span class="pf-c-label pf-m-blue">
+                                    <span class="pf-c-label__content">
+                                        <span class="pf-c-label__icon">
+                                            <i class="fas fa-fw fa-info-circle" aria-hidden="true"></i>
+                                        </span>준비중
+                                    </span>
+                                </span>
+                                <span class="pf-c-label__content" style="margin-left:4px">가상머신 설정 파일 생성</span>
+                            </div>
+                            <div class="pf-c-content" style="margin-top:15px;margin-left:15px">
+                                <span class="pf-c-label pf-m-green">
+                                    <span class="pf-c-label__content">
+                                        <span class="pf-c-label__icon">
+                                            <i class="fas fa-fw fa-check-circle" aria-hidden="true"></i>
+                                        </span>완료됨
+                                    </span>
+                                </span>
+                                <span class="pf-c-label__content" style="margin-left:4px">클라우드센터 가상머신 생성</span>
+                            </div>
+                            <div class="pf-c-content" style="margin-top:15px;margin-left:15px">
+                                <span class="pf-c-label pf-m-orange">
+                                    <span class="pf-c-label__content">
+                                        <span class="pf-c-label__icon">
+                                            <i class="fas fa-fw fa-play" aria-hidden="true"></i>
+                                        </span>진행중
+                                    </span>
+                                </span>
+                                <span class="pf-c-label__content" style="margin-left:4px">클라우드센터 가상머신 시작</span>
+                            </div>
+                            <div class="pf-c-content" style="margin-top:15px;margin-left:15px">
+                                <span class="pf-c-label pf-m-red">
+                                    <span class="pf-c-label__content">
+                                        <span class="pf-c-label__icon">
+                                            <i class="fas fa-fw fa-exclamation-circle" aria-hidden="true"></i>
+                                        </span>중단됨
+                                    </span>
+                                </span>
+                                <span class="pf-c-label__content" style="margin-left:4px">클라우드센터 가상머신 설정</span>
                             </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cloud-vm-finish">

--- a/src/features/cloud-vm-wizard.js
+++ b/src/features/cloud-vm-wizard.js
@@ -18,7 +18,13 @@ $(document).ready(function(){
     $('#div-modal-wizard-cloud-vm-additional').hide();
     $('#div-modal-wizard-cloud-vm-ssh-key').hide();
     $('#div-modal-wizard-cloud-vm-review').hide();
+    $('#div-modal-wizard-cloud-vm-deploy').hide();
     $('#div-modal-wizard-cloud-vm-finish').hide();
+
+    $('#div-accordion-cloud-vm-failover-cluster').hide();
+    $('#div-accordion-cloud-vm-compute-network').hide();
+    $('#div-accordion-cloud-vm-additional').hide();
+    $('#div-accordion-cloud-vm-ssh-key').hide();
 
     // $('#nav-button-cloud-vm-review').addClass('pf-m-disabled');
     $('#nav-button-cloud-vm-finish').addClass('pf-m-disabled');
@@ -246,15 +252,7 @@ $('#button-next-step-modal-wizard-cloud-vm').on('click', function(){
         cur_step_wizard_cloud_vm = "7";
     }
     else if (cur_step_wizard_cloud_vm == "7") {
-        resetCloudVMWizard();
-
-        $('#div-modal-wizard-cloud-vm-finish').show();
-        $('#nav-button-cloud-vm-finish').addClass('pf-m-current');
-    
-        $('#button-next-step-modal-wizard-cloud-vm').html('완료');
-        $('#button-next-step-modal-wizard-cloud-vm').attr('disabled', false);
-        $('#button-before-step-modal-wizard-cloud-vm').attr('disabled', true);
-        $('#button-cancel-config-modal-wizard-cloud-vm').attr('disabled', false);
+        deployCloudCenterVM();
     
         cur_step_wizard_cloud_vm = "8";
     }
@@ -362,6 +360,71 @@ $('#button-cancel-config-modal-wizard-cloud-vm').on('click', function(){
 
 /* Footer 영역에서 발생하는 이벤트 처리 끝 */
 
+/* HTML Object에서 발생하는 이벤트 처리 시작 */
+
+// 설정확인 단계의 아코디언 개체에서 발생하는 이벤트의 처리
+$('#button-accordion-cloud-vm-failover-cluster').on('click', function(){
+    if ($('#button-accordion-cloud-vm-failover-cluster').attr("aria-expanded") == "false") {
+        $('#button-accordion-cloud-vm-failover-cluster').attr("aria-expanded", "true");
+        $('#button-accordion-cloud-vm-failover-cluster').addClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-failover-cluster').fadeIn();
+        $('#div-accordion-cloud-vm-failover-cluster').addClass("pf-m-expanded");
+    }
+    else {
+        $('#button-accordion-cloud-vm-failover-cluster').attr("aria-expanded", "false");
+        $('#button-accordion-cloud-vm-failover-cluster').removeClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-failover-cluster').fadeOut();
+        $('#div-accordion-cloud-vm-failover-cluster').removeClass("pf-m-expanded");
+    }
+});
+
+$('#button-accordion-cloud-vm-compute-network').on('click', function(){
+    if ($('#button-accordion-cloud-vm-compute-network').attr("aria-expanded") == "false") {
+        $('#button-accordion-cloud-vm-compute-network').attr("aria-expanded", "true");
+        $('#button-accordion-cloud-vm-compute-network').addClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-compute-network').fadeIn();
+        $('#div-accordion-cloud-vm-compute-network').addClass("pf-m-expanded");
+    }
+    else {
+        $('#button-accordion-cloud-vm-compute-network').attr("aria-expanded", "false");
+        $('#button-accordion-cloud-vm-compute-network').removeClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-compute-network').fadeOut();
+        $('#div-accordion-cloud-vm-compute-network').removeClass("pf-m-expanded");
+    }
+});
+
+$('#button-accordion-cloud-vm-additional').on('click', function(){
+    if ($('#button-accordion-cloud-vm-additional').attr("aria-expanded") == "false") {
+        $('#button-accordion-cloud-vm-additional').attr("aria-expanded", "true");
+        $('#button-accordion-cloud-vm-additional').addClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-additional').fadeIn();
+        $('#div-accordion-cloud-vm-additional').addClass("pf-m-expanded");
+    }
+    else {
+        $('#button-accordion-cloud-vm-additional').attr("aria-expanded", "false");
+        $('#button-accordion-cloud-vm-additional').removeClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-additional').fadeOut();
+        $('#div-accordion-cloud-vm-additional').removeClass("pf-m-expanded");
+    }
+});
+
+$('#button-accordion-cloud-vm-ssh-key').on('click', function(){
+    if ($('#button-accordion-cloud-vm-ssh-key').attr("aria-expanded") == "false") {
+        $('#button-accordion-cloud-vm-ssh-key').attr("aria-expanded", "true");
+        $('#button-accordion-cloud-vm-ssh-key').addClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-ssh-key').fadeIn();
+        $('#div-accordion-cloud-vm-ssh-key').addClass("pf-m-expanded");
+    }
+    else {
+        $('#button-accordion-cloud-vm-ssh-key').attr("aria-expanded", "false");
+        $('#button-accordion-cloud-vm-ssh-key').removeClass("pf-m-expanded");
+        $('#div-accordion-cloud-vm-ssh-key').fadeOut();
+        $('#div-accordion-cloud-vm-ssh-key').removeClass("pf-m-expanded");
+    }
+});
+
+/* HTML Object에서 발생하는 이벤트 처리 끝 */
+
 /* 함수 정의 시작 */
 
 /**
@@ -382,6 +445,7 @@ function resetCloudVMWizard(){
     $('#div-modal-wizard-cloud-vm-additional').hide();
     $('#div-modal-wizard-cloud-vm-ssh-key').hide();
     $('#div-modal-wizard-cloud-vm-review').hide();
+    $('#div-modal-wizard-cloud-vm-deploy').hide();
     $('#div-modal-wizard-cloud-vm-finish').hide();
 
     // 모든 사이드버튼 '기본' 속성 삭제
@@ -397,6 +461,52 @@ function resetCloudVMWizard(){
 
     // footer 버튼 속성 설정
     $('#button-next-step-modal-wizard-cloud-vm').html('다음');
+}
+
+/**
+ * Meathod Name : deployCloudCenterVM  
+ * Date Created : 2021.03.17
+ * Writer  : 박동혁
+ * Description : 클라우드센터 가상머신을 배포하는 작업을 화면에 표시하도록 하는 함수
+ * Parameter : 없음
+ * Return  : 없음
+ * History  : 2021.03.17 최초 작성
+ */
+function deployCloudCenterVM() {
+    resetCloudVMWizard();
+    
+    $('#div-modal-wizard-cloud-vm-deploy').show();
+    $('#nav-button-cloud-vm-finish').addClass('pf-m-current');
+
+    $('#button-next-step-modal-wizard-cloud-vm').html('완료');
+    $('#button-next-step-modal-wizard-cloud-vm').attr('disabled', true);
+    $('#button-before-step-modal-wizard-cloud-vm').attr('disabled', true);
+    $('#button-cancel-config-modal-wizard-cloud-vm').attr('disabled', false);
+
+    setTimeout(showDivisionCloudVMConfigFinish, 5000);
+}
+
+/**
+ * Meathod Name : showDivisionCloudVMConfigFinish
+ * Date Created : 2021.03.17
+ * Writer  : 박동혁
+ * Description : 클라우드센터 가상머신을 배포한 후 마지막 페이지를 보여주는 함수
+ * Parameter : 없음
+ * Return  : 없음
+ * History  : 2021.03.17 최초 작성
+ */
+ function showDivisionCloudVMConfigFinish() {
+    resetCloudVMWizard();
+
+    $('#div-modal-wizard-cloud-vm-finish').show();
+    $('#nav-button-cloud-vm-finish').addClass('pf-m-current');
+
+    $('#button-next-step-modal-wizard-cloud-vm').html('완료');
+    $('#button-next-step-modal-wizard-cloud-vm').attr('disabled', false);
+    $('#button-before-step-modal-wizard-cloud-vm').attr('disabled', true);
+    $('#button-cancel-config-modal-wizard-cloud-vm').attr('disabled', false);
+
+    cur_step_wizard_cloud_vm = "8";
 }
 
 /* 함수 정의 끝 */

--- a/src/features/cloud-vm-wizard.js
+++ b/src/features/cloud-vm-wizard.js
@@ -423,6 +423,28 @@ $('#button-accordion-cloud-vm-ssh-key').on('click', function(){
     }
 });
 
+// 네트워크 구성에서 "서비스네트워크"의 선택여부가 변경되었을 때의 이벤트 처리
+$('#form-checkbox-svc-network').on('change', function(){
+    if ($('#form-checkbox-svc-network').is(':checked') == true) {
+        // 서비스네트워크를 사용하으로 선택한 경우 서비스네트워크 브릿지 선택상자를 활성화 함
+        $('#form-select-cloud-vm-svc-parent').attr('disabled', false);
+
+        // 추가 네트워크 정보에서 서비스 NIC 정보를 입력할 수 있도록 활성화 해야 함
+        $('#form-input-cloud-vm-svc-nic-ip').attr('disabled', false);
+        $('#form-input-cloud-vm-svc-vlan').attr('disabled', false);
+        $('#form-input-cloud-vm-svc-gw').attr('disabled', false);
+    }
+    else {
+        // 서비스네트워크를 사용하지 않음으로 선택한 경우 서비스네트워크 브릿지 선택상자를 비활성화 함
+        $('#form-select-cloud-vm-svc-parent').attr('disabled', true);
+
+        // 추가 네트워크 정보에서 서비스 NIC 정보를 입력할 수 없도록 비활성화 해야 함
+        $('#form-input-cloud-vm-svc-nic-ip').attr('disabled', true);
+        $('#form-input-cloud-vm-svc-vlan').attr('disabled', true);
+        $('#form-input-cloud-vm-svc-gw').attr('disabled', true);
+    }
+});
+
 /* HTML Object에서 발생하는 이벤트 처리 끝 */
 
 /* 함수 정의 시작 */
@@ -474,7 +496,7 @@ function resetCloudVMWizard(){
  */
 function deployCloudCenterVM() {
     resetCloudVMWizard();
-    
+
     $('#div-modal-wizard-cloud-vm-deploy').show();
     $('#nav-button-cloud-vm-finish').addClass('pf-m-current');
 

--- a/src/features/cluster-config-prepare.html
+++ b/src/features/cluster-config-prepare.html
@@ -337,7 +337,7 @@
                                         </dl>
                                     </div>
                                 </div>
-                              </div>
+                            </div>
                         </div>
                         <div class="pf-c-wizard__main-body" id="div-modal-wizard-cluster-config-finish">
                             <p>


### PR DESCRIPTION
클라우드센터 VM 배포마법사  UI 프로토타입을 작성하였습니다. 
다음과 같은 절차 및 내용으로 구성됩니다. 

프로토타입 형식 : 모달 형식의 마법사
단계 및 내용

    1. 개요 : 마법사의 목적 및 마법사 단계, 입력 정보에 대한 간단한 안내
    2. 장애조치 클러스터 설정 : PCS 클러스터 구성을 위한 정보를 입력받는 단계
        - 클러스터 멤버 수 : 3대로 고정 (Readonly TextBox)
        - 호스트 1, 2, 3번의 호스트명, IP Addr 정보 (필수입력)
    3. 클라우드센터 VM 설정 : 가상머신의 CPU, Memory, ROOT Disk, NIC 할당에 대한 정보를 입력받는 단계
        - 컴퓨트 : CPU Core, Memory 정보를 콤보상자에서 선택함. ROOT Disk는 70GB로 고정함
        - 네트워크 : 관리네트워크는 기본적으로 사용하며, 서비스 네트워크는 선택임. 
    4. 추가네트워크 정보 : 클라우드센터 VM의 호스트명, NIC의 IP, Gateway 등의 정보를 입력 받는 단계
    5. SSH Key 정보 : 클라우드센터 VM의 SSH인증을 위한 키 파일 정보를 입력 받는 단계
    6. 설정 확인 : 입력한 정보의 설정을 확인하는 단계
    7. 배포 : 실제 가상머신을 배포하는 단계
    8. 완료 : 가상머신 완료 후 표시되는 정보 표시 단계

위의 단계 중 배포 단계는 "설정 확인" 단계에서 "다음" 버튼을 누르면 표시하도록 프로토타입을 만들었으며, 배포단계에서 5초 후 자동으로 완료단계로 넘어가도록 만들어 놓았습니다. 

프로토타입을 이용해 기능을 개발할 때에는 만들어진 이벤트 처리 함수를 수정하여 작성해야 합니다. 
